### PR TITLE
Changed react.propType to prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "flexbox",
     "grid"
   ],
+  "dependencies": {
+    "prop-types": "^15.6.0",
+  },
   "author": "Derek Tor <derekmuoktor@gmail.com> (http://derektor.me)",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grid"
   ],
   "dependencies": {
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.0"
   },
   "author": "Derek Tor <derekmuoktor@gmail.com> (http://derektor.me)",
   "license": "MIT",

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from "prop-types";
 import {screenSize} from '../lib/ScreenSize';
 import {isHidden, getComponentWidth, getComponentOffset} from '../lib/helpers';
 import {View} from 'react-native';

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from "prop-types";
 import {screenSize} from '../lib/ScreenSize';
 import {isHidden} from '../lib/helpers';
 import {View} from 'react-native';


### PR DESCRIPTION
react-native removed PropTypes, now accessible in prop-types.

Fixes undefined is not an object (evaluating '_react.PropTypes.number') in both Column.js and Row.js error.